### PR TITLE
Authorization init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@casl/ability": "^6.3.3",
+        "@casl/prisma": "^1.3.3",
         "@nestjs/axios": "^0.1.0",
         "@nestjs/common": "^9.0.11",
         "@nestjs/core": "^9.0.11",
@@ -790,6 +792,30 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@casl/ability": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.3.3.tgz",
+      "integrity": "sha512-UzbqsE9etu6QzZrRmqIyVun2kztAzJ46Tz7lC/2P2buCE6B6Ll7Vptz7JTQtGwapLbeKo2jS7dL966TVOQ7x4g==",
+      "dependencies": {
+        "@ucast/mongo2js": "^1.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
+      }
+    },
+    "node_modules/@casl/prisma": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@casl/prisma/-/prisma-1.3.3.tgz",
+      "integrity": "sha512-G55pyNsIJlS18lfcf4Gj56g0TSHFF3kh8G6rLuUIac2e+lLzrkSWxSS15+YqPDkkVRr0rynKyCR/60CXNTMnhA==",
+      "dependencies": {
+        "@ucast/core": "^1.10.0",
+        "@ucast/js": "^3.0.1"
+      },
+      "peerDependencies": {
+        "@casl/ability": "^5.3.0 || ^6.0.0",
+        "@prisma/client": "^2.14.0 || ^3.0.0 || ^4.0.0"
+      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -2441,6 +2467,37 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ucast/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-sXKbvQiagjFh2JCpaHUa64P4UdJbOxYeC5xiZFn8y6iYdb0WkismduE+RmiJrIjw/eLDYmIEXiQeIYYowmkcAw=="
+    },
+    "node_modules/@ucast/js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.2.tgz",
+      "integrity": "sha512-zxNkdIPVvqJjHI7D/iK8Aai1+59yqU+N7bpHFodVmiTN7ukeNiGGpNmmSjQgsUw7eNcEBnPrZHNzp5UBxwmaPw==",
+      "dependencies": {
+        "@ucast/core": "^1.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.2.tgz",
+      "integrity": "sha512-/zH1TdBJlYGKKD+Wh0oyD+aBvDSWrwHcD8b4tUL9UgHLhzHtkEnMVFuxbw3SRIRsAa01wmy06+LWt+WoZdj1Bw==",
+      "dependencies": {
+        "@ucast/core": "^1.4.1"
+      }
+    },
+    "node_modules/@ucast/mongo2js": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.3.3.tgz",
+      "integrity": "sha512-sBPtMUYg+hRnYeVYKL+ATm8FaRPdlU9PijMhGYKgsPGjV9J4Ks41ytIjGayvKUnBOEhiCaKUUnY4qPeifdqATw==",
+      "dependencies": {
+        "@ucast/core": "^1.6.1",
+        "@ucast/js": "^3.0.0",
+        "@ucast/mongo": "^2.4.0"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -3620,9 +3677,9 @@
       }
     },
     "node_modules/dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dev": true,
       "dependencies": {
         "asap": "^2.0.0",
@@ -4483,25 +4540,28 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "dev": true,
       "dependencies": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/formidable/node_modules/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
       },
@@ -9380,6 +9440,23 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@casl/ability": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.3.3.tgz",
+      "integrity": "sha512-UzbqsE9etu6QzZrRmqIyVun2kztAzJ46Tz7lC/2P2buCE6B6Ll7Vptz7JTQtGwapLbeKo2jS7dL966TVOQ7x4g==",
+      "requires": {
+        "@ucast/mongo2js": "^1.3.0"
+      }
+    },
+    "@casl/prisma": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@casl/prisma/-/prisma-1.3.3.tgz",
+      "integrity": "sha512-G55pyNsIJlS18lfcf4Gj56g0TSHFF3kh8G6rLuUIac2e+lLzrkSWxSS15+YqPDkkVRr0rynKyCR/60CXNTMnhA==",
+      "requires": {
+        "@ucast/core": "^1.10.0",
+        "@ucast/js": "^3.0.1"
+      }
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -10639,6 +10716,37 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@ucast/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-sXKbvQiagjFh2JCpaHUa64P4UdJbOxYeC5xiZFn8y6iYdb0WkismduE+RmiJrIjw/eLDYmIEXiQeIYYowmkcAw=="
+    },
+    "@ucast/js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.2.tgz",
+      "integrity": "sha512-zxNkdIPVvqJjHI7D/iK8Aai1+59yqU+N7bpHFodVmiTN7ukeNiGGpNmmSjQgsUw7eNcEBnPrZHNzp5UBxwmaPw==",
+      "requires": {
+        "@ucast/core": "^1.0.0"
+      }
+    },
+    "@ucast/mongo": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.2.tgz",
+      "integrity": "sha512-/zH1TdBJlYGKKD+Wh0oyD+aBvDSWrwHcD8b4tUL9UgHLhzHtkEnMVFuxbw3SRIRsAa01wmy06+LWt+WoZdj1Bw==",
+      "requires": {
+        "@ucast/core": "^1.4.1"
+      }
+    },
+    "@ucast/mongo2js": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.3.3.tgz",
+      "integrity": "sha512-sBPtMUYg+hRnYeVYKL+ATm8FaRPdlU9PijMhGYKgsPGjV9J4Ks41ytIjGayvKUnBOEhiCaKUUnY4qPeifdqATw==",
+      "requires": {
+        "@ucast/core": "^1.6.1",
+        "@ucast/js": "^3.0.0",
+        "@ucast/mongo": "^2.4.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -11557,9 +11665,9 @@
       "dev": true
     },
     "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dev": true,
       "requires": {
         "asap": "^2.0.0",
@@ -12215,22 +12323,25 @@
       }
     },
     "formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "dev": true,
       "requires": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "dependencies": {
         "qs": {
-          "version": "6.9.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
-          "dev": true
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@casl/ability": "^6.3.3",
+    "@casl/prisma": "^1.3.3",
     "@nestjs/axios": "^0.1.0",
     "@nestjs/common": "^9.0.11",
     "@nestjs/core": "^9.0.11",

--- a/prisma/migrations/20221220180930_add_user_isadmin_field/migration.sql
+++ b/prisma/migrations/20221220180930_add_user_isadmin_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isAdmin" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model User {
   firstName              String
   lastName               String
   email                  String                @unique
+  isAdmin                Boolean               @default(false)
   //subjects    Subject[]
   ownedGroups            Group[]
   memberships            UserToGroup[]

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,9 +1,11 @@
 import { JwtService } from '@nestjs/jwt'
 import { Test, TestingModule } from '@nestjs/testing'
 import { User } from '@prisma/client'
+import { PrismaModule } from 'src/prisma/prisma.module'
 import { UsersService } from '../users/users.service'
 import { AuthController } from './auth.controller'
 import { AuthService } from './auth.service'
+import { CaslAbilityFactory } from './casl-ability.factory'
 
 describe('AuthController', () => {
   let controller: AuthController
@@ -22,9 +24,11 @@ describe('AuthController', () => {
     }
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [PrismaModule],
       controllers: [AuthController],
       providers: [
         AuthService,
+        CaslAbilityFactory,
         {
           provide: JwtService,
           useValue: fakejwtService,
@@ -47,6 +51,7 @@ describe('AuthController', () => {
     it('should create a token for the user', async () => {
       const user: User = {
         id: 1,
+        isAdmin: false,
         authSchId: '1',
         email: 'noreply@example.com',
         firstName: 'test',

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,5 +1,5 @@
 import { HttpModule } from '@nestjs/axios'
-import { Module } from '@nestjs/common'
+import { forwardRef, Module } from '@nestjs/common'
 import { JwtModule } from '@nestjs/jwt'
 import { PassportModule } from '@nestjs/passport'
 import { PrismaModule } from 'src/prisma/prisma.module'
@@ -7,11 +7,12 @@ import { UsersModule } from 'src/users/users.module'
 import { AuthController } from './auth.controller'
 import { AuthService } from './auth.service'
 import { AuthschStrategy } from './authsch.strategy'
+import { CaslAbilityFactory } from './casl-ability.factory'
 import { JwtStrategy } from './jwt.strategy'
 
 @Module({
   imports: [
-    UsersModule,
+    forwardRef(() => UsersModule),
     PrismaModule,
     HttpModule,
     JwtModule.register({
@@ -21,6 +22,7 @@ import { JwtStrategy } from './jwt.strategy'
     PassportModule.register({}),
   ],
   controllers: [AuthController],
-  providers: [AuthschStrategy, JwtStrategy, AuthService],
+  providers: [AuthschStrategy, JwtStrategy, AuthService, CaslAbilityFactory],
+  exports: [CaslAbilityFactory],
 })
 export class AuthModule {}

--- a/src/auth/authorization.guard.spec.ts
+++ b/src/auth/authorization.guard.spec.ts
@@ -1,0 +1,7 @@
+import { AuthorizationGuard } from './authorization.guard';
+
+describe('AuthorizationGuard', () => {
+  it('should be defined', () => {
+    expect(new AuthorizationGuard()).toBeDefined();
+  });
+});

--- a/src/auth/authorization.guard.spec.ts
+++ b/src/auth/authorization.guard.spec.ts
@@ -1,7 +1,0 @@
-import { AuthorizationGuard } from './authorization.guard';
-
-describe('AuthorizationGuard', () => {
-  it('should be defined', () => {
-    expect(new AuthorizationGuard()).toBeDefined();
-  });
-});

--- a/src/auth/authorization.guard.ts
+++ b/src/auth/authorization.guard.ts
@@ -3,13 +3,13 @@ import {
   ExecutionContext,
   HttpException,
   HttpStatus,
-  Injectable
+  Injectable,
 } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import {
   AppSubjects,
   CaslAbilityFactory,
-  Permissions
+  Permissions,
 } from './casl-ability.factory'
 
 @Injectable()
@@ -37,24 +37,29 @@ export class AuthorizationGuard implements CanActivate {
 
     switch (requestSubject) {
       case 'Group': {
-          const ability = await this.caslAbilityFactory.createForGroup(
+        const ability = await this.caslAbilityFactory.createForGroup(
           request.user,
           paramId,
         )
         return ability.can(action, requestSubject)
       }
       case 'Subject': {
-        const ability = this.caslAbilityFactory.createForSubject(
-          request.user,
-        )
+        const ability = this.caslAbilityFactory.createForSubject(request.user)
         return ability.can(action, requestSubject)
       }
       case 'User': {
-        const ability = this.caslAbilityFactory.createForUser(request.user, paramId)
+        const ability = this.caslAbilityFactory.createForUser(
+          request.user,
+          paramId,
+        )
         return ability.can(action, requestSubject)
       }
       case 'Consultation': {
-        // TODO
+        const ability = await this.caslAbilityFactory.createForConsultation(
+          request.user,
+          paramId,
+        )
+        return ability.can(action, requestSubject)
       }
       default:
         return true

--- a/src/auth/authorization.guard.ts
+++ b/src/auth/authorization.guard.ts
@@ -44,6 +44,12 @@ export class AuthorizationGuard implements CanActivate {
         )
         return ability.can(action, requestSubject)
       }
+      case 'Subject': {
+        const ability = await this.caslAbilityFactory.createForSubject(
+          request.user,
+        )
+        return ability.can(action, requestSubject)
+      }
       default:
         return true
     }

--- a/src/auth/authorization.guard.ts
+++ b/src/auth/authorization.guard.ts
@@ -1,0 +1,51 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import {
+  AppSubjects,
+  CaslAbilityFactory,
+  Permissions,
+} from './casl-ability.factory'
+
+@Injectable()
+export class AuthorizationGuard implements CanActivate {
+  constructor(
+    private caslAbilityFactory: CaslAbilityFactory,
+    private reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const action = this.reflector.get<Permissions>(
+      'permission',
+      context.getHandler(),
+    )
+    const requestSubject = this.reflector.get<AppSubjects>(
+      'subject',
+      context.getClass(),
+    )
+    if (!action || !requestSubject) return true
+    const request = context.switchToHttp().getRequest()
+
+    switch (requestSubject) {
+      case 'Group': {
+        const groupId: number = +request.params.id
+        if (Number.isNaN(groupId) && request.params.id) {
+          throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST)
+        }
+
+        const ability = await this.caslAbilityFactory.createForGroup(
+          request.user,
+          groupId,
+        )
+        return ability.can(action, requestSubject)
+      }
+      default:
+        return true
+    }
+  }
+}

--- a/src/auth/casl-ability.factory.ts
+++ b/src/auth/casl-ability.factory.ts
@@ -6,7 +6,7 @@ import {
   ConsultationRequest,
   Group,
   Subject,
-  User,
+  User
 } from '@prisma/client'
 import { GroupRoles } from 'src/groups/dto/GroupEntity.dto'
 import { PrismaService } from 'src/prisma/prisma.service'
@@ -30,6 +30,7 @@ export enum Permissions {
   AddMember = 'add_member',
   ApproveMember = 'approve_member',
   PromoteMember = 'promote_member',
+  PromoteUser = 'promote_user',
 }
 
 @Injectable()
@@ -64,12 +65,34 @@ export class CaslAbilityFactory {
     return build()
   }
 
-  createForSubject = async (user: User) => {
+  createForSubject = (user: User) => {
     const { can, build } = new AbilityBuilder<AppAbility>(createPrismaAbility)
 
     if (user.isAdmin) {
       can(Permissions.Manage, 'Subject')
     }
+
+    return build()
+  }
+
+  createForUser = (currentUser: User, userIdToManage: number) => {
+    const { can, cannot, build } = new AbilityBuilder<AppAbility>(createPrismaAbility)
+    if (currentUser.id === userIdToManage) {
+      can(Permissions.Manage, 'User')
+    }
+
+    if (currentUser.isAdmin) {
+      can(Permissions.Manage, 'User')
+    } else {
+      cannot(Permissions.PromoteUser, 'User')
+    }
+    return build()
+  }
+
+  createForConsultation = (user: User, consultationId: number) => {
+    const { can, cannot, build } = new AbilityBuilder<AppAbility>(createPrismaAbility)
+
+    // TODO
 
     return build()
   }

--- a/src/auth/casl-ability.factory.ts
+++ b/src/auth/casl-ability.factory.ts
@@ -63,4 +63,14 @@ export class CaslAbilityFactory {
     }
     return build()
   }
+
+  createForSubject = async (user: User) => {
+    const { can, build } = new AbilityBuilder<AppAbility>(createPrismaAbility)
+
+    if (user.isAdmin) {
+      can(Permissions.Manage, 'Subject')
+    }
+
+    return build()
+  }
 }

--- a/src/auth/casl-ability.factory.ts
+++ b/src/auth/casl-ability.factory.ts
@@ -1,0 +1,66 @@
+import { AbilityBuilder, PureAbility } from '@casl/ability'
+import { createPrismaAbility, PrismaQuery, Subjects } from '@casl/prisma'
+import { Injectable } from '@nestjs/common'
+import {
+  Consultation,
+  ConsultationRequest,
+  Group,
+  Subject,
+  User,
+} from '@prisma/client'
+import { GroupRoles } from 'src/groups/dto/GroupEntity.dto'
+import { PrismaService } from 'src/prisma/prisma.service'
+
+export type AppSubjects = Subjects<{
+  User: User
+  Group: Group
+  Subject: Subject
+  Consultation: Consultation
+  ConsultationRequest: ConsultationRequest
+}>
+
+type AppAbility = PureAbility<[string, AppSubjects], PrismaQuery>
+
+export enum Permissions {
+  Manage = 'manage', // all permissions
+  Create = 'create',
+  Read = 'read',
+  Update = 'update',
+  Delete = 'delete',
+  AddMember = 'add_member',
+  ApproveMember = 'approve_member',
+  PromoteMember = 'promote_member',
+}
+
+@Injectable()
+export class CaslAbilityFactory {
+  constructor(private prisma: PrismaService) {}
+
+  createForGroup = async (user: User, groupId: number) => {
+    const { can, build } = new AbilityBuilder<AppAbility>(createPrismaAbility)
+
+    if (user.isAdmin) {
+      can(Permissions.Manage, 'Group')
+    }
+
+    const group = await this.prisma.group.findUnique({
+      where: { id: groupId },
+      include: { members: { where: { userId: user.id } } },
+    })
+
+    if (group?.ownerId === user.id) {
+      can(Permissions.Update, 'Group')
+      can(Permissions.Delete, 'Group')
+      can(Permissions.PromoteMember, 'Group')
+    }
+
+    if (
+      group?.members.length > 0 &&
+      [GroupRoles.OWNER, GroupRoles.ADMIN].includes(group?.members[0].role)
+    ) {
+      can(Permissions.AddMember, 'Group')
+      can(Permissions.ApproveMember, 'Group')
+    }
+    return build()
+  }
+}

--- a/src/auth/decorator/authorizationSubject.decorator.ts
+++ b/src/auth/decorator/authorizationSubject.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common'
+import { AppSubjects } from 'src/auth/casl-ability.factory'
+
+export const AuthorizationSubject = (subject: AppSubjects) =>
+  SetMetadata('subject', subject)

--- a/src/auth/decorator/jwtAuth.decorator.ts
+++ b/src/auth/decorator/jwtAuth.decorator.ts
@@ -3,10 +3,15 @@ import { ApiBearerAuth } from '@nestjs/swagger'
 
 import { Injectable } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
+import { AuthorizationGuard } from '../authorization.guard'
 
 @Injectable()
 class JwtAuthGuard extends AuthGuard('jwt') {}
 
 export function JwtAuth() {
-  return applyDecorators(UseGuards(JwtAuthGuard), ApiBearerAuth())
+  return applyDecorators(
+    UseGuards(JwtAuthGuard),
+    ApiBearerAuth(),
+    UseGuards(AuthorizationGuard),
+  )
 }

--- a/src/auth/decorator/requiredPermission.ts
+++ b/src/auth/decorator/requiredPermission.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common'
+import { Permissions } from 'src/auth/casl-ability.factory'
+
+export const RequiredPermission = (permission: Permissions) =>
+  SetMetadata('permission', permission)

--- a/src/consultations/consultations.controller.spec.ts
+++ b/src/consultations/consultations.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { AuthModule } from 'src/auth/auth.module'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { ConsultationRequestService } from './consultationRequest.service'
 import { ConsultationsController } from './consultations.controller'
@@ -12,7 +13,7 @@ describe('ConsultationsController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [PrismaModule],
+      imports: [PrismaModule, AuthModule],
       controllers: [ConsultationsController],
       providers: [
         ConsultationsService,

--- a/src/consultations/consultations.controller.ts
+++ b/src/consultations/consultations.controller.ts
@@ -19,7 +19,10 @@ import { Response } from 'express'
 import { createReadStream, unlink } from 'fs'
 import { diskStorage } from 'multer'
 import { extname, join } from 'path'
+import { Permissions } from 'src/auth/casl-ability.factory'
+import { AuthorizationSubject } from 'src/auth/decorator/authorizationSubject.decorator'
 import { JwtAuth } from 'src/auth/decorator/jwtAuth.decorator'
+import { RequiredPermission } from 'src/auth/decorator/requiredPermission'
 import { CurrentUser } from 'src/current-user.decorator'
 import { UserEntity } from 'src/users/dto/UserEntity.dto'
 import { ApiController } from 'src/utils/apiController.decorator'
@@ -38,6 +41,7 @@ import { PresentationService } from './presentation.service'
 import { RatingService } from './rating.service'
 
 @ApiController('consultations')
+@AuthorizationSubject('Consultation')
 export class ConsultationsController {
   constructor(
     private readonly consultationsService: ConsultationsService,
@@ -74,6 +78,7 @@ export class ConsultationsController {
   }
 
   @JwtAuth()
+  @RequiredPermission(Permissions.Update)
   @Patch(':id')
   update(
     @Param('id', ParseIntPipe) id: number,
@@ -83,6 +88,7 @@ export class ConsultationsController {
   }
 
   @JwtAuth()
+  @RequiredPermission(Permissions.Delete)
   @Delete(':id')
   remove(@Param('id', ParseIntPipe) id: number): Promise<ConsultationEntity> {
     return this.consultationsService.remove(id)
@@ -130,6 +136,8 @@ export class ConsultationsController {
     })
   }
 
+  @JwtAuth()
+  @RequiredPermission(Permissions.Update)
   @Patch(':id/file')
   @UseInterceptors(
     FileInterceptor('file', {
@@ -177,6 +185,8 @@ export class ConsultationsController {
     }
   }
 
+  @JwtAuth()
+  @RequiredPermission(Permissions.DownloadFile)
   @Get(':id/file')
   async getFile(
     @Param('id', ParseIntPipe) id: number,

--- a/src/consultations/consultations.module.ts
+++ b/src/consultations/consultations.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common'
+import { AuthModule } from 'src/auth/auth.module'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { ConsultationRequestService } from './consultationRequest.service'
 import { ConsultationsController } from './consultations.controller'
@@ -8,7 +9,7 @@ import { PresentationService } from './presentation.service'
 import { RatingService } from './rating.service'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, AuthModule],
   controllers: [ConsultationsController],
   providers: [
     ConsultationsService,

--- a/src/groups/groups.controller.spec.ts
+++ b/src/groups/groups.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { AuthModule } from 'src/auth/auth.module'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { GroupsController } from './groups.controller'
 import { GroupsService } from './groups.service'
@@ -8,7 +9,7 @@ describe('GroupsController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [PrismaModule],
+      imports: [PrismaModule, AuthModule],
       controllers: [GroupsController],
       providers: [GroupsService],
     }).compile()

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
+import { AuthModule } from 'src/auth/auth.module'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { GroupsController } from './groups.controller'
 import { GroupsService } from './groups.service'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, AuthModule],
   controllers: [GroupsController],
   providers: [GroupsService],
 })

--- a/src/seed/data/users.ts
+++ b/src/seed/data/users.ts
@@ -7,6 +7,7 @@ export const seededUsers: UserEntity[] = [
     firstName: 'Jakab',
     lastName: 'Gipsz',
     email: 'gipsz@jakab.eu',
+    isAdmin: true,
   },
   {
     id: 1000002,
@@ -14,6 +15,7 @@ export const seededUsers: UserEntity[] = [
     firstName: 'John',
     lastName: 'Doe',
     email: 'john@doe.eu',
+    isAdmin: false,
   },
   {
     id: 1000003,
@@ -21,6 +23,7 @@ export const seededUsers: UserEntity[] = [
     firstName: 'Feri',
     lastName: 'Azabizonyos',
     email: 'milyen@feri.eu',
+    isAdmin: false,
   },
   {
     id: 1000004,
@@ -28,6 +31,7 @@ export const seededUsers: UserEntity[] = [
     firstName: 'Elek',
     lastName: 'Teszt',
     email: 'teszt.elek@gmail.eu',
+    isAdmin: false,
   },
   {
     id: 1000005,
@@ -35,5 +39,6 @@ export const seededUsers: UserEntity[] = [
     firstName: 'Foo',
     lastName: 'Bar',
     email: 'foo@bar.eu',
+    isAdmin: false,
   },
 ]

--- a/src/subject/subject.controller.spec.ts
+++ b/src/subject/subject.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { AuthModule } from 'src/auth/auth.module'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { SubjectController } from './subject.controller'
 import { SubjectService } from './subject.service'
@@ -8,7 +9,7 @@ describe('SubjectController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [PrismaModule],
+      imports: [PrismaModule, AuthModule],
       controllers: [SubjectController],
       providers: [SubjectService],
     }).compile()

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -8,29 +8,39 @@ import {
   Post,
 } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
+import { Permissions } from 'src/auth/casl-ability.factory'
+import { AuthorizationSubject } from 'src/auth/decorator/authorizationSubject.decorator'
+import { JwtAuth } from 'src/auth/decorator/jwtAuth.decorator'
+import { RequiredPermission } from 'src/auth/decorator/requiredPermission'
 import { ApiController } from 'src/utils/apiController.decorator'
 import { SubjectService } from './subject.service'
 
-@ApiController('subject')
+@JwtAuth()
+@ApiController('subjects')
+@AuthorizationSubject('Subject')
 export class SubjectController {
   constructor(private readonly subjectService: SubjectService) {}
 
   @Post()
+  @RequiredPermission(Permissions.Create)
   create(@Body() createSubjectDto: Prisma.SubjectCreateInput) {
     return this.subjectService.create(createSubjectDto)
   }
 
   @Get()
+  @RequiredPermission(Permissions.Read)
   findAll() {
     return this.subjectService.findAll()
   }
 
   @Get(':id')
+  @RequiredPermission(Permissions.Read)
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.subjectService.findOne(id)
   }
 
   @Patch(':id')
+  @RequiredPermission(Permissions.Update)
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateSubjectDto: Prisma.SubjectUpdateInput,
@@ -39,6 +49,7 @@ export class SubjectController {
   }
 
   @Delete(':id')
+  @RequiredPermission(Permissions.Delete)
   remove(@Param('id', ParseIntPipe) id: number) {
     return this.subjectService.remove(id)
   }

--- a/src/subject/subject.module.ts
+++ b/src/subject/subject.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
+import { AuthModule } from 'src/auth/auth.module'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { SubjectController } from './subject.controller'
 import { SubjectService } from './subject.service'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, AuthModule],
   controllers: [SubjectController],
   providers: [SubjectService],
 })

--- a/src/users/dto/CreateUser.dto.ts
+++ b/src/users/dto/CreateUser.dto.ts
@@ -1,4 +1,4 @@
 import { OmitType } from '@nestjs/swagger'
 import { UserEntity } from 'src/users/dto/UserEntity.dto'
 
-export class CreateUserDto extends OmitType(UserEntity, ['id']) {}
+export class CreateUserDto extends OmitType(UserEntity, ['id', 'isAdmin']) {}

--- a/src/users/dto/UserEntity.dto.ts
+++ b/src/users/dto/UserEntity.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger'
-import { IsEmail, IsInt, IsNotEmpty, IsUUID, Min } from 'class-validator'
+import {
+  IsBoolean,
+  IsEmail,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsUUID,
+  Min,
+} from 'class-validator'
 
 export class UserEntity {
   @IsInt()
@@ -18,6 +26,10 @@ export class UserEntity {
   @IsEmail()
   @ApiProperty({ example: 'noreply@example.com' })
   email: string
+
+  @IsBoolean()
+  @IsOptional()
+  isAdmin: boolean
 
   constructor(partial: Partial<UserEntity>) {
     Object.assign(this, partial)

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { User } from '@prisma/client'
+import { AuthModule } from 'src/auth/auth.module'
 import { UsersController } from './users.controller'
 import { UsersService } from './users.service'
 
@@ -20,6 +21,7 @@ describe('UsersController', () => {
     }
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [AuthModule],
       controllers: [UsersController],
       providers: [
         {

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,10 +1,11 @@
-import { Module } from '@nestjs/common'
+import { forwardRef, Module } from '@nestjs/common'
+import { AuthModule } from 'src/auth/auth.module'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { UsersController } from './users.controller'
 import { UsersService } from './users.service'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, forwardRef(() => AuthModule)],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -28,6 +28,10 @@ export class UsersService {
     return this.prisma.user.update({ data, where: { id: id } })
   }
 
+  async promoteUser(id: number): Promise<User> {
+    return this.prisma.user.update({ data: { isAdmin: true }, where: { id: id } })
+  }
+
   async remove(id: number): Promise<User> {
     return this.prisma.user.delete({ where: { id: id } })
   }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,5 +1,5 @@
-import { Test, TestingModule } from '@nestjs/testing'
 import { INestApplication } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
 import * as request from 'supertest'
 import { AppModule } from './../src/app.module'
 


### PR DESCRIPTION
Implemented advanced authorization on the following entities using the CASL library: `User`, `Subject`, and `Group`. TODO: #64 

Endpoints only accessible with certain permissions must have the permission specified with the `@RequiredPermission() `decorator and the Authorization guard will check whether the current user has that permission. If they don't, it automatically returns 403. Permission rules have to be defined in the `casl-abilitiy.factory` file. 

Added an isAdmin boolean filed to the User relation. Admins have permission to edit or delete any entities, and they're the only users who can do anything with subjects. Also added an endpoint to promote users, only accessible to admins.

Closes #54 , #62 