### PR TITLE
send new jwt if admin status changed in /profile

### DIFF
--- a/src/auth/casl-ability.factory.ts
+++ b/src/auth/casl-ability.factory.ts
@@ -106,7 +106,18 @@ export class CaslAbilityFactory {
 
     const consultation = await this.prisma.consultation.findUnique({
       where: { id: consultationId },
-      include: { presentations: true },
+      include: {
+        presentations: true,
+        targetGroups: {
+          include: {
+            members: {
+              where: {
+                userId: user.id,
+              },
+            },
+          },
+        },
+      },
     })
 
     if (consultation === null) {
@@ -127,7 +138,10 @@ export class CaslAbilityFactory {
       can(Permissions.Update, 'Consultation')
       can(Permissions.Delete, 'Consultation')
       can(Permissions.DownloadFile, 'Consultation')
-    } else {
+    } else if (
+      consultation.targetGroups.length === 0 ||
+      consultation.targetGroups.some((g) => g.members.length > 0)
+    ) {
       can(Permissions.JoinConsultation, 'Consultation')
     }
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -40,8 +40,10 @@ export class UsersController {
   }
 
   @Get('profile')
-  findProfile(@CurrentUser() user: UserEntity): Promise<UserEntity> {
-    return this.usersService.profile(user.id)
+  findProfile(
+    @CurrentUser() user: UserEntity,
+  ): Promise<UserEntity & { jwt?: string }> {
+    return this.usersService.profile(user)
   }
 
   @Get(':id')

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,11 +1,19 @@
 import { forwardRef, Module } from '@nestjs/common'
+import { JwtModule } from '@nestjs/jwt'
 import { AuthModule } from 'src/auth/auth.module'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { UsersController } from './users.controller'
 import { UsersService } from './users.service'
 
 @Module({
-  imports: [PrismaModule, forwardRef(() => AuthModule)],
+  imports: [
+    PrismaModule,
+    forwardRef(() => AuthModule),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+      signOptions: { expiresIn: '2 days' },
+    }),
+  ],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,14 +1,25 @@
+import { JwtService } from '@nestjs/jwt'
 import { Test, TestingModule } from '@nestjs/testing'
 import { PrismaModule } from '../prisma/prisma.module'
 import { UsersService } from './users.service'
 
 describe('UsersService', () => {
   let service: UsersService
+  let fakejwtService: Partial<JwtService>
 
   beforeEach(async () => {
+    fakejwtService = {
+      sign: jest.fn().mockReturnValue('token'),
+    }
     const module: TestingModule = await Test.createTestingModule({
       imports: [PrismaModule],
-      providers: [UsersService],
+      providers: [
+        UsersService,
+        {
+          provide: JwtService,
+          useValue: fakejwtService,
+        },
+      ],
     }).compile()
 
     service = module.get<UsersService>(UsersService)


### PR DESCRIPTION
Related to https://github.com/kir-dev/konzisite-frontend/pull/65

If someone promotes you to admin, the next time you refresh the page (or AuthContext fetches your profile data) your jwt will update, granting you the admin permissions.

I based this branch on the wrong one, hopefully Github will be able to handle it.