### PR TITLE
findAll endpoint improvements for subjects, groups and users

### DIFF
--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -49,6 +49,12 @@ export class GroupsController {
     @Query('search') nameFilter?: string,
     @Query('limit') limit?: number,
   ): Promise<GroupPreviewDto[]> {
+    if (limit < 0) {
+      throw new HttpException(
+        'Érvénytelen limit paraméter!',
+        HttpStatus.BAD_REQUEST,
+      )
+    }
     return this.groupsService.findAll(user.id, nameFilter, limit)
   }
 

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -19,8 +19,8 @@ import { JwtAuth } from 'src/auth/decorator/jwtAuth.decorator'
 import { RequiredPermission } from 'src/auth/decorator/requiredPermission'
 import { ManyUniqueUsersDto } from 'src/users/dto/ManyUniqueUsers.dto'
 import { UserEntity } from 'src/users/dto/UserEntity.dto'
-import { CreateManyResponse } from 'src/utils/CreateManyResponse.dto'
 import { ApiController } from 'src/utils/apiController.decorator'
+import { CreateManyResponse } from 'src/utils/CreateManyResponse.dto'
 import { CreateGroupDto } from './dto/CreateGroup.dto'
 import { GroupDetailsDto } from './dto/GroupDetails.dto'
 import { GroupEntity } from './dto/GroupEntity.dto'
@@ -39,12 +39,17 @@ export class GroupsController {
     name: 'search',
     required: false,
   })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+  })
   @Get()
-  async findAll(
+  findAll(
     @CurrentUser() user: UserEntity,
-    @Query('search') nameFilter: string,
+    @Query('search') nameFilter?: string,
+    @Query('limit') limit?: number,
   ): Promise<GroupPreviewDto[]> {
-    return this.groupsService.findAll(user.id, nameFilter)
+    return this.groupsService.findAll(user.id, nameFilter, limit)
   }
 
   @Get(':id')

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -11,7 +11,7 @@ import { GroupRoles } from './dto/GroupEntity.dto'
 export class GroupsService {
   constructor(private prisma: PrismaService) {}
 
-  async findAll(userId: number, nameFilter?: string) {
+  async findAll(userId: number, nameFilter?: string, limit?: number) {
     const groups = await this.prisma.group.findMany({
       include: {
         owner: publicUserProjection,
@@ -36,6 +36,12 @@ export class GroupsService {
         name: {
           contains: nameFilter ?? '',
           mode: 'insensitive',
+        },
+      },
+      take: limit ? limit : undefined,
+      orderBy: {
+        members: {
+          _count: 'desc',
         },
       },
     })

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -26,12 +26,12 @@ import { CurrentUser } from 'src/auth/decorator/current-user.decorator'
 import { JwtAuth } from 'src/auth/decorator/jwtAuth.decorator'
 import { RequiredPermission } from 'src/auth/decorator/requiredPermission'
 import { UserEntity } from 'src/users/dto/UserEntity.dto'
+import { ApiController } from 'src/utils/apiController.decorator'
 import { CreateManyResponse } from 'src/utils/CreateManyResponse.dto'
 import { FileExtensionValidator } from 'src/utils/FileExtensionValidator'
 import { FileMaxSizeValidator } from 'src/utils/FileMaxSizeValidator'
-import { ApiController } from 'src/utils/apiController.decorator'
 import { CreateSubjectDto } from './dto/CreateSubject.dto'
-import { Major } from './dto/SubjectEntity.dto'
+import { Major, SubjectEntity } from './dto/SubjectEntity.dto'
 import { UpdateSubjectDto } from './dto/UpdateSubject.dto'
 import { SubjectService } from './subject.service'
 
@@ -45,9 +45,22 @@ export class SubjectController {
     name: 'search',
     required: false,
   })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+  })
   @Get()
-  findAll(@Query('search') nameFilter: string) {
-    return this.subjectService.findAll(nameFilter)
+  findAll(
+    @Query('search') nameFilter?: string,
+    @Query('limit') limit?: number,
+  ): Promise<SubjectEntity[]> {
+    if (limit < 0) {
+      throw new HttpException(
+        'Érvénytelen limit paraméter!',
+        HttpStatus.BAD_REQUEST,
+      )
+    }
+    return this.subjectService.findAll(nameFilter, limit)
   }
 
   @Get(':id')

--- a/src/subject/subject.service.ts
+++ b/src/subject/subject.service.ts
@@ -10,7 +10,7 @@ import { UpdateSubjectDto } from './dto/UpdateSubject.dto'
 export class SubjectService {
   constructor(private prisma: PrismaService) {}
 
-  async findAll(nameFilter?: string): Promise<SubjectEntity[]> {
+  async findAll(nameFilter?: string, limit?: number): Promise<SubjectEntity[]> {
     return this.prisma.subject.findMany({
       where: {
         name: {
@@ -18,6 +18,12 @@ export class SubjectService {
           mode: 'insensitive',
         },
       },
+      orderBy: {
+        consultations: {
+          _count: 'desc',
+        },
+      },
+      take: limit ? limit : undefined,
     })
   }
 

--- a/src/users/dto/UserList.dto.ts
+++ b/src/users/dto/UserList.dto.ts
@@ -1,0 +1,6 @@
+import { UserPreview } from './UserPreview.dto'
+
+export class UserList {
+  userList: UserPreview[]
+  userCount: number
+}

--- a/src/users/dto/UserPreview.dto.ts
+++ b/src/users/dto/UserPreview.dto.ts
@@ -5,8 +5,3 @@ export class UserPreview extends PublicUser {
   averageRating: number
   attendances: number
 }
-
-export class UserList {
-  userList: UserPreview[]
-  userCount: number
-}

--- a/src/users/dto/UserPreview.dto.ts
+++ b/src/users/dto/UserPreview.dto.ts
@@ -5,3 +5,8 @@ export class UserPreview extends PublicUser {
   averageRating: number
   attendances: number
 }
+
+export class UserList {
+  userList: UserPreview[]
+  userCount: number
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -17,7 +17,7 @@ import { RequiredPermission } from 'src/auth/decorator/requiredPermission'
 import { ApiController } from 'src/utils/apiController.decorator'
 import { UserDetails } from './dto/UserDetails'
 import { UserEntity } from './dto/UserEntity.dto'
-import { UserPreview } from './dto/UserPreview.dto'
+import { UserList } from './dto/UserPreview.dto'
 import { UserProfileDto } from './dto/UserProfile.dto'
 import { UsersService } from './users.service'
 
@@ -36,7 +36,7 @@ export class UsersController {
     @Query('search') nameFilter: string,
     @Query('page') page: number,
     @Query('pageSize') pageSize: number,
-  ): Promise<UserPreview[]> {
+  ): Promise<UserList> {
     return this.usersService.findAll(nameFilter, page, pageSize)
   }
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -17,7 +17,7 @@ import { RequiredPermission } from 'src/auth/decorator/requiredPermission'
 import { ApiController } from 'src/utils/apiController.decorator'
 import { UserDetails } from './dto/UserDetails'
 import { UserEntity } from './dto/UserEntity.dto'
-import { UserList } from './dto/UserPreview.dto'
+import { UserList } from './dto/UserList.dto'
 import { UserProfileDto } from './dto/UserProfile.dto'
 import { UsersService } from './users.service'
 
@@ -31,12 +31,26 @@ export class UsersController {
     name: 'search',
     required: false,
   })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+  })
+  @ApiQuery({
+    name: 'pageSize',
+    required: false,
+  })
   @Get()
   findAll(
-    @Query('search') nameFilter: string,
-    @Query('page') page: number,
-    @Query('pageSize') pageSize: number,
+    @Query('search') nameFilter?: string,
+    @Query('page') page?: number,
+    @Query('pageSize') pageSize?: number,
   ): Promise<UserList> {
+    if (page < 0 || pageSize < 0) {
+      throw new HttpException(
+        'Érvénytelen lapozási paraméterek!',
+        HttpStatus.BAD_REQUEST,
+      )
+    }
     return this.usersService.findAll(nameFilter, page, pageSize)
   }
 


### PR DESCRIPTION
For subjects and groups:
Added an optional limit parameter. If specified, the endpoint will only return at most, that many records. Also added sorting (descending by no of consultations and members, respectively)

For users:
full pagination support, with pageNumber and pageSize. The endpoint returns the total number of records as well. Sorted by the number of presentations.

Related to https://github.com/kir-dev/konzisite-frontend/pull/104